### PR TITLE
[v0.5] Append "zabo_version" to connect widget URL

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -65,8 +65,9 @@ class API {
         throw err
       }
     } else {
-      const url = `${this.connectUrl}/connect?clientId=${this.clientId}&origin=${encodeURIComponent(window.location.host)}&zabo_env=${this.env}`
+      const url = `${this.connectUrl}/connect?clientId=${this.clientId}&origin=${encodeURIComponent(window.location.host)}&zabo_env=${this.env}&zabo_version=${process.env.PACKAGE_VERSION}`
       this.isWaitingForConnector = true
+
       if (interfaceType == 'iframe') {
         this.connector = document.createElement('iframe')
         this.connector.width = width
@@ -74,7 +75,7 @@ class API {
         this.connector.src = url
         document.querySelector(attachTo).appendChild(this.connector)
       } else {
-        this.connector = window.open(url, 'Zabo Connect', `width=${width},height=${height},resizable,scrollbars=yes,status=1`)
+        this.connector = window.open(url.trim(), 'Zabo Connect', `width=${width},height=${height},resizable,scrollbars=yes,status=1`)
       }
     }
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,10 +17,13 @@
 'use strict'
 const { isBrowser } = require('./utils')
 const DEFAULT_API_HOST = 'https://api.zabo.com'
-const SANDBOX_BASE_PATH = '/sandbox-v0'
-const LIVE_BASE_PATH = '/v0'
-
 const DEFAULT_CONNECT_PATH = 'https://connect.zabo.com'
+
+// This should be updated to {PACKAGE_VERSION} in the future, in order to call
+// the right Zabo API instance running for this specific version.
+const VERSION = 0 // const VERSION = PACKAGE_VERSION
+const SANDBOX_BASE_PATH = `/sandbox-v${VERSION}`
+const LIVE_BASE_PATH = `/v${VERSION}`
 
 module.exports = (host, connectHost) => {
   let thisHost, thisConnectHost

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,8 @@
 const path = require('path')
 const webpack = require('webpack')
+const fs = require('fs')
+const pkg = fs.readFileSync('./package.json')
+const version = JSON.parse(pkg).version || 0
 
 module.exports = () => {
   return {
@@ -10,6 +13,9 @@ module.exports = () => {
       path: path.resolve(__dirname, 'dist')
     },
     plugins: [
+      new webpack.EnvironmentPlugin({
+        PACKAGE_VERSION: version
+      }),
       new webpack.BannerPlugin({
         banner: `
           @Copyright (c) 2019-present, Zabo & Modular, Inc. All rights reserved.


### PR DESCRIPTION
The zabo version value is extracted from package.json's version number for now. In a near future we could discuss the possibility of enabling users to enter a custom API version number during Zabo.init(), but for now the package.json works just fine.

Required changes to the zabo-connect-widget have been made to accommodate this and were merged to its develop branch.