### PR TITLE
[ZAPI-981] Check get and create deposit address errors for self-custody wallets

### DIFF
--- a/src/resources/accounts.js
+++ b/src/resources/accounts.js
@@ -97,10 +97,10 @@ class Accounts {
       'binance',
     ]
 
-    for (provider of providersWithStaticDepositAddresses) {
-      if (provider === this.data.wallet_provider_name) {
+    for (let provider of providersWithStaticDepositAddresses) {
+      if (provider === this.data.wallet_provider.name) {
         console.warn(`[Zabo] Provider '${provider}' does not support dynamic address generation. Fallbacking to accounts.getDepositAddress()... More details: https://zabo.com/docs#get-deposit-address`)
-        return this.getDepositAddress(currency)
+        return this.getDepositAddresses(currency)
       }
     }
 


### PR DESCRIPTION
The current implementation complies with the behavior described in the issue (ZAPI-981).
There is only a small inconsistency with the expected error:
```
{
  "error_type": 404,
  "message": "BTC is not a supported currency for this account."
}
```
instead of
```
{
  "error_type": 400,
  "message": "not supported for this wallet provider"
}
```
This error comes from the api server.