### PR TITLE
[ZAPI-1157] Enable server-side create/get addresses for accounts (accounts resource)

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -70,12 +70,12 @@ class API {
 
     if (utils.isNode()) {
       this.axios.defaults.headers.common['X-Zabo-Key'] = this.apiKey
-      resources(this, true).then(resources => this.resources = resources)
+      this.resources = resources(this, true)
     } else {
       this.interfaces = {}
       this.connectUrl = urls.CONNECT_BASE_URL
       this._setEventListeners()
-      resources(this, false).then(resources => this.resources = resources)
+      this.resources = resources(this, false)
     }
   }
 

--- a/src/resources/accounts.js
+++ b/src/resources/accounts.js
@@ -153,19 +153,21 @@ class Accounts {
   }
 }
 
-module.exports = async (api) => {
+module.exports = (api) => {
   let accounts = new Accounts(api)
   if (api.ethereum) {
-    let ethConnection = await api.ethereum.connect(api.useNode, api.useAddress)
-    accounts.data = ethConnection.data
-    accounts.node = ethConnection.node
-    accounts.get = () => { return accounts.data }
-    accounts.getBalances = ({ currencies } = {}) => { return ethConnection.getBalance(currencies) }
-    accounts.createDepositAddress = () => { return { currency: 'ETH', address: accounts.data.address } }
-    if (!api.sendAppCryptoData) {
-      accounts.create = () => { throw new SDKError(400, '[Zabo] Not available in decentralized mode. See: https://zabo.com/docs#decentralized-mode') }
-    }
-    accounts.getDepositAddress = () => { return { currency: 'ETH', address: accounts.data.address } }
+    api.ethereum.connect(api.useNode, api.useAddress)
+      .then(ethConnection => {
+        accounts.data = ethConnection.data
+        accounts.node = ethConnection.node
+        accounts.get = () => { return accounts.data }
+        accounts.getBalances = ({ currencies } = {}) => { return ethConnection.getBalance(currencies) }
+        accounts.createDepositAddress = () => { return { currency: 'ETH', address: accounts.data.address } }
+        if (!api.sendAppCryptoData) {
+          accounts.create = () => { throw new SDKError(400, '[Zabo] Not available in decentralized mode. See: https://zabo.com/docs#decentralized-mode') }
+        }
+        accounts.getDepositAddress = () => { return { currency: 'ETH', address: accounts.data.address } }
+      })
   }
   return accounts
 }

--- a/src/resources/accounts.js
+++ b/src/resources/accounts.js
@@ -108,18 +108,20 @@ class Accounts {
       throw new SDKError(400, '[Zabo] Missing or invalid `currency` parameter. See: https://zabo.com/docs##create-a-deposit-address')
     }
 
-    const providersWithStaticDepositAddresses = [
-      'metamask',
-      'ledger',
-      'hedera',
-      'address-only',
-      'binance',
-    ]
+    if (utils.isBrowser()) {
+      const providersWithStaticDepositAddresses = [
+        'metamask',
+        'ledger',
+        'hedera',
+        'address-only',
+        'binance',
+      ]
 
-    for (let provider of providersWithStaticDepositAddresses) {
-      if (provider === this.data.wallet_provider.name) {
-        console.warn(`[Zabo] Provider '${provider}' does not support dynamic address generation. Fallbacking to accounts.getDepositAddress()... More details: https://zabo.com/docs#get-deposit-address`)
-        return this.getDepositAddresses(currency)
+      for (let provider of providersWithStaticDepositAddresses) {
+        if (provider === this.data.wallet_provider.name) {
+          console.warn(`[Zabo] Provider '${provider}' does not support dynamic address generation. Fallbacking to accounts.getDepositAddress()... More details: https://zabo.com/docs#get-deposit-address`)
+          return this.getDepositAddresses(currency)
+        }
       }
     }
 

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -20,6 +20,7 @@ module.exports = async (api, isNode) => {
     return {
       utils: require('./utils')(api),
       users: require('./users')(api),
+      accounts: require('./accounts')(api),
       applications: require('./applications')(api),
       currencies: require('./currencies')(api),
       transactions: require('./transactions')(api),
@@ -31,11 +32,10 @@ module.exports = async (api, isNode) => {
     api.ethereum = ethereum
   }
 
-  let accounts = await require('./accounts')(api)
   let resources = {
     utils: require('./utils')(api),
     applications: require('./applications')(api),
-    accounts: accounts,
+    accounts: require('./accounts')(api),
     currencies: require('./currencies')(api),
     transactions: require('./transactions')(api)
   }

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -15,12 +15,12 @@
  */
 const { ethereum } = require('../networks')
 
-module.exports = async (api, isNode) => {
+module.exports = (api, isNode) => {
   if (isNode) {
     return {
       utils: require('./utils')(api),
       users: require('./users')(api),
-      accounts: await require('./accounts')(api),
+      accounts: require('./accounts')(api),
       applications: require('./applications')(api),
       currencies: require('./currencies')(api),
       transactions: require('./transactions')(api),
@@ -35,7 +35,7 @@ module.exports = async (api, isNode) => {
   let resources = {
     utils: require('./utils')(api),
     applications: require('./applications')(api),
-    accounts: await require('./accounts')(api),
+    accounts: require('./accounts')(api),
     currencies: require('./currencies')(api),
     transactions: require('./transactions')(api)
   }

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -20,7 +20,7 @@ module.exports = async (api, isNode) => {
     return {
       utils: require('./utils')(api),
       users: require('./users')(api),
-      accounts: require('./accounts')(api),
+      accounts: await require('./accounts')(api),
       applications: require('./applications')(api),
       currencies: require('./currencies')(api),
       transactions: require('./transactions')(api),
@@ -35,7 +35,7 @@ module.exports = async (api, isNode) => {
   let resources = {
     utils: require('./utils')(api),
     applications: require('./applications')(api),
-    accounts: require('./accounts')(api),
+    accounts: await require('./accounts')(api),
     currencies: require('./currencies')(api),
     transactions: require('./transactions')(api)
   }


### PR DESCRIPTION
This PR is a breaking change in the `accounts.createDepositAddress` and 
`accounts.getDepositAddresses` arguments.

From:
```
accounts.createDepositAddress( currency )
accounts.getDepositAddresses( currency )
```
To:
```
accounts.createDepositAddress({ currency[, accountId ] )
accounts.getDepositAddresses({ currency[, accountId ] )
```

Besides that, the other methods where reviewed to work on or inform limitations when running in server side.