### PR TITLE
Transaction getList fix

### DIFF
--- a/src/resources/transactions.js
+++ b/src/resources/transactions.js
@@ -65,7 +65,7 @@ class Transactions {
   }
 
   async getList ({ userId, accountId, currency = '', limit = 25, cursor = '' } = {}) {
-    utils.validateLimitParameter(limit)
+    utils.validateListParameters(limit)
 
     let url = null
 

--- a/src/resources/transactions.js
+++ b/src/resources/transactions.js
@@ -65,7 +65,7 @@ class Transactions {
   }
 
   async getList ({ userId, accountId, currency = '', limit = 25, cursor = '' } = {}) {
-    utils.validateListParameters(limit, cursor)
+    utils.validateLimitParameter(limit)
 
     let url = null
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,14 +46,10 @@ function getZaboSession () {
   return decodeURIComponent(document.cookie.replace(new RegExp('(?:(?:^|.*;)\\s*' + encodeURIComponent('zabosession').replace(/[-.+*]/g, '\\$&') + '\\s*\\=\\s*([^;]*).*$)|^.*$'), '$1')) || null
 }
 
-function validateLimitParameter (limit) {
+function validateListParameters (limit, cursor) {
   if (limit && limit > 50) {
     throw new SDKError(400, ErrorMessages.invalidLimit)
   }
-}
-
-function validateListParameters (limit, cursor) {
-  validateLimitParameter(limit)
   if (cursor && !uuidValidate(cursor, 4)) {
     throw new SDKError(400, ErrorMessages.invalidUUID)
   }
@@ -205,7 +201,6 @@ function createPaginator (payload, api) {
 module.exports = {
   generateHMACSignature,
   getZaboSession,
-  validateLimitParameter,
   validateListParameters,
   getTxObjectForEthereumRequest,
   isBrowser,

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,10 +46,14 @@ function getZaboSession () {
   return decodeURIComponent(document.cookie.replace(new RegExp('(?:(?:^|.*;)\\s*' + encodeURIComponent('zabosession').replace(/[-.+*]/g, '\\$&') + '\\s*\\=\\s*([^;]*).*$)|^.*$'), '$1')) || null
 }
 
-function validateListParameters (limit, cursor) {
+function validateLimitParameter (limit) {
   if (limit && limit > 50) {
     throw new SDKError(400, ErrorMessages.invalidLimit)
   }
+}
+
+function validateListParameters (limit, cursor) {
+  validateLimitParameter(limit)
   if (cursor && !uuidValidate(cursor, 4)) {
     throw new SDKError(400, ErrorMessages.invalidUUID)
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -205,6 +205,7 @@ function createPaginator (payload, api) {
 module.exports = {
   generateHMACSignature,
   getZaboSession,
+  validateLimitParameter,
   validateListParameters,
   getTxObjectForEthereumRequest,
   isBrowser,

--- a/test/resources/transactions.spec.js
+++ b/test/resources/transactions.spec.js
@@ -95,15 +95,6 @@ describe('Zabo SDK Transactions Resource', () => {
     response.message.should.containEql('limit')
   })
 
-  it('transactions.getList() should fail if an invalid `cursor` is provided', async function () {
-    const response = await transactions.getList({ cursor: 'not_a_valid_timestamp' }).should.be.rejected()
-
-    response.should.be.an.Error()
-
-    response.error_type.should.be.equal(400)
-    response.message.should.containEql('cursor')
-  })
-
   it('transactions.getList() should return the list of transactions', async function () {
     const data = {
       userId: '35b6b5dd-90a4-478e-b7b4-8712370f3333',


### PR DESCRIPTION
The current transaction getList function ensure that the cursor is a valid UUID but the zabo api now returns transaction id in many forms such as:

- `0x54e431ef4dede09910b00b1cd9bc10f4c87ea7981b775a03f0bb1dc283d57d8b-555703935`
- `Internal transfer 10077999044`

which does not follow the uuid format.

This PR removes any check on the cursor parameter in the transaction resource.