### PR TITLE
Remove origin param from GET teams/info

### DIFF
--- a/src/resources/teams.js
+++ b/src/resources/teams.js
@@ -51,8 +51,7 @@ class Teams {
       }
 
       try {
-        const origin = encodeURIComponent(window ? window.location.host : '')
-        this.data = await this.api.request('GET', `/teams/info?client_id=${this.api.clientId}&origin=${origin}`, '', true)
+        this.data = await this.api.request('GET', `/teams/info?client_id=${this.api.clientId}`, '', true)
       } catch (err) {
         throw new SDKError(err.error_type, err.message, err.request_id)
       }


### PR DESCRIPTION
For React Native compatibility, remove no longer needed `origin` param from `GET teams/origin` request