### PR TITLE
Included `index.d.ts` in the `src` directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.1",
   "description": "Zabo SDK for JS",
   "main": "dist/index.js",
-  "types": "./dist/@types/index.d.ts",
+  "types": "./src/index.d.ts",
   "scripts": {
     "getv": "echo $npm_package_version",
     "test": "NODE_ENV=test ./node_modules/mocha/bin/mocha -r jsdom-global/register --recursive test/ --exit --timeout 10000",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,34 @@
+declare const _exports: ZaboClass;
+export = _exports
+export type ZaboClass = Zabo;
+/**
+ * Zabo main class definition.
+ */
+declare class Zabo {
+    /**
+     * Initialize the Zabo SDK.
+     * @param {{
+     *  clientId?: String
+     *  env: 'live' | 'sandbox'
+     *  apiKey?: String
+     *  secretKey?: String
+     *  autoConnect?: Boolean
+     *  apiVersion?: 'v0' | 'v1' | {}
+     * }} config Zabo initialization config.
+     * @returns {typeof Promise<import('../dist/@types/sdk')>} The Zabo SDK.
+     */
+    init(config?: {
+        clientId?: string;
+        env: 'live' | 'sandbox';
+        apiKey?: string;
+        secretKey?: string;
+        autoConnect?: boolean;
+        apiVersion?: 'v0' | 'v1' | {};
+    }): Promise<typeof import('../dist/@types/sdk')>;
+    /**
+     * Get an instance of the ZaboSDK.
+     * @returns {typeof import('../dist/@types/sdk')} An instance of ZaboSDK.
+     */
+    get instance(): typeof import('../dist/@types/sdk');
+    get version(): any;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "include": ["./src/**/*.js"],
   "exclude": [
+    "./src/index.d.ts",
     "./src/index.js",
     "node_modules",
     "dist"


### PR DESCRIPTION
`index.d.ts` is a manually patched file. It's patched as a workaround to make `ZaboSDK` a type that you could use.

This PR:
- Switches the `types` config in `package.json` to `./src/index.d.ts`
- Adds `index.d.ts` to `src/`
- Excludes `./src/index.d.ts` from TypeScript builds
- Excludes `./src/index.js` from TypeScript builds