### PR TITLE
Added packages in package.json to block from browser (a fix for Angular)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zabo-sdk-js",
-  "version": "1.3.3-beta.0",
+  "version": "1.3.3-beta.1",
   "description": "Zabo SDK for JS",
   "main": "dist/index.js",
   "types": "./src/index.d.ts",
@@ -61,6 +61,11 @@
   "browser": {
     "net": false,
     "fs": false,
+    "https": false,
+    "http": false,
+    "crypto": false,
+    "stream": false,
+    "zlib": false,
     "child_process": false
   },
   "standard": {


### PR DESCRIPTION
@flave was having a problem with our SDK in Angular. This hotfix blocks unsupported packages from loading within the browser.

<a href="https://discord.com/channels/533336922970521600/607688477747707905/866692018066554890">Click here to see conversation in Discord</a>